### PR TITLE
png: add a helper script `extract_chunks.py`

### DIFF
--- a/image/png/README.md
+++ b/image/png/README.md
@@ -41,14 +41,7 @@ into the file
 using the following commands:
 
 ```console
-$ grep -b -o -a -F 'skMf' evernote-skitch-mac-v1.1.png
-13843:skMf
-$ xxd -s "$((13843 - 4))" -l 4 evernote-skitch-mac-v1.1.png
-0000360f: 0000 0205                                ....
-$ LC_ALL=C dd if=evernote-skitch-mac-v1.1.png of=evernote-skitch-mac-v1.1-skMf-raw.json bs=1 skip="$((13843 + 4))" count="$((0x0205))"
-517+0 records in
-517+0 records out
-517 bytes copied, 0.0013973 s, 517 kB/s
+$ ./extract_chunks.py -t skMf -o evernote-skitch-mac-v1.1-skMf-raw.json evernote-skitch-mac-v1.1.png
 $ jq -b . evernote-skitch-mac-v1.1-skMf-raw.json > evernote-skitch-mac-v1.1-skMf.json
 ```
 
@@ -99,14 +92,7 @@ into the file
 using the following commands:
 
 ```console
-$ grep -b -o -a -F 'skMf' evernote-skitch-mac-v1.2.png
-43262:skMf
-$ xxd -s "$((43262 - 4))" -l 4 evernote-skitch-mac-v1.2.png
-0000a8fa: 0000 063d                                ...=
-$ LC_ALL=C dd if=evernote-skitch-mac-v1.2.png of=evernote-skitch-mac-v1.2-skMf-raw.json bs=1 skip="$((43262 + 4))" count="$((0x063d))"
-1597+0 records in
-1597+0 records out
-1597 bytes (1.6 kB, 1.6 KiB) copied, 0.002097 s, 799 kB/s
+$ ./extract_chunks.py -t skMf -o evernote-skitch-mac-v1.2-skMf-raw.json evernote-skitch-mac-v1.2.png
 $ jq -b . evernote-skitch-mac-v1.2-skMf-raw.json > evernote-skitch-mac-v1.2-skMf.json
 ```
 
@@ -154,14 +140,7 @@ include the `skMf` chunk (it's almost certainly uncopyrightable because it only
 contains generic metadata):
 
 ```console
-$ grep -b -o -a -F 'skMf' evernote-skitch-win32-v1.1.png
-417094:skMf
-$ xxd -s "$((417094 - 4))" -l 4 evernote-skitch-win32-v1.1.png
-00065d42: 0000 0246                                ...F
-$ LC_ALL=C dd if=evernote-skitch-win32-v1.1.png of=evernote-skitch-win32-v1.1-skMf-raw.json bs=1 skip="$((417094 + 4))" count="$((0x0246))"
-582+0 records in
-582+0 records out
-582 bytes copied, 0.0008786 s, 582 kB/s
+$ ./extract_chunks.py -t skMf -o evernote-skitch-win32-v1.1-skMf-raw.json evernote-skitch-win32-v1.1.png
 $ jq -b . evernote-skitch-win32-v1.1-skMf-raw.json > evernote-skitch-win32-v1.1-skMf.json
 ```
 

--- a/image/png/extract_chunks.py
+++ b/image/png/extract_chunks.py
@@ -23,6 +23,13 @@ PNG_CHUNK_TYPE_RE = re.compile(r"[A-Za-z]{4}")
 PACKER_U4BE = struct.Struct(">I")
 
 
+def validate_chunk_type(chunk_type: str) -> None:
+    if PNG_CHUNK_TYPE_RE.fullmatch(chunk_type) is None:
+        raise ValueError(
+            f"expected an ASCII 4-letter chunk type, but got {chunk_type!r}"
+        )
+
+
 @dataclass
 class ChunkBodySpan:
     type: str
@@ -70,10 +77,7 @@ def copyfileobj_with_limit(
 
 
 def run_single(file_path: Path, chunk_type: str, outfile: Path) -> None:
-    if PNG_CHUNK_TYPE_RE.fullmatch(chunk_type) is None:
-        raise ValueError(
-            f"expected an ASCII 4-letter chunk type, but got {chunk_type!r}"
-        )
+    validate_chunk_type(chunk_type)
 
     with file_path.open("rb") as f:
         chunk_body_spans = get_chunk_body_spans(f)
@@ -103,11 +107,7 @@ def run_single(file_path: Path, chunk_type: str, outfile: Path) -> None:
 def run(files: list[Path], chunk_types: set[str], outdir: Path) -> None:
     outdir.mkdir(exist_ok=True)
     for chunk_type in chunk_types:
-        if PNG_CHUNK_TYPE_RE.fullmatch(chunk_type) is None:
-            raise ValueError(
-                f"expected an ASCII 4-letter chunk type, but got {chunk_type!r}"
-            )
-
+        validate_chunk_type(chunk_type)
         (outdir / chunk_type).mkdir(exist_ok=True)
 
     for file_path in files:

--- a/image/png/extract_chunks.py
+++ b/image/png/extract_chunks.py
@@ -105,7 +105,7 @@ def run_single(file_path: Path, chunk_type: str, outfile: Path) -> None:
 
 
 def run(files: list[Path], chunk_types: set[str], outdir: Path) -> None:
-    outdir.mkdir(exist_ok=True)
+    outdir.mkdir(parents=True, exist_ok=True)
     for chunk_type in chunk_types:
         validate_chunk_type(chunk_type)
         (outdir / chunk_type).mkdir(exist_ok=True)

--- a/image/png/extract_chunks.py
+++ b/image/png/extract_chunks.py
@@ -113,11 +113,21 @@ def run(files: list[Path], chunk_types: set[str], outdir: Path) -> None:
     for file_path in files:
         with file_path.open("rb") as f:
             chunk_body_spans = get_chunk_body_spans(f)
+            if not chunk_body_spans:
+                continue
+
+            # We want all chunk indices from one input file zero-padded to the
+            # same width so that the output file names sort naturally (e.g.
+            # `-09.bin` before `-10.bin`), so we need to determine the maximum
+            # chunk index width.
+            index_width = len(str(len(chunk_body_spans) - 1))
+
             for i, span in enumerate(chunk_body_spans):
                 chunk_type = span.type
                 if chunk_type not in chunk_types:
                     continue
-                out_path = outdir / chunk_type / f"{file_path.name}-{i}.bin"
+                name = f"{file_path.name}-{i:0{index_width}d}.bin"
+                out_path = outdir / chunk_type / name
                 with out_path.open("wb") as out_f:
                     f.seek(span.offset)
                     remaining = copyfileobj_with_limit(f, out_f, span.length)
@@ -126,9 +136,7 @@ def run(files: list[Path], chunk_types: set[str], outdir: Path) -> None:
                         f"{file_path}: chunk {i} of type {chunk_type!r} is truncated"
                         f" (wanted {span.length} bytes, but only {span.length - remaining} bytes written)"
                     )
-                    out_path.replace(
-                        outdir / chunk_type / f"{file_path.name}-{i}.bin.trunc"
-                    )
+                    out_path.replace(out_path.with_name(name + ".trunc"))
 
 
 def main() -> None:

--- a/image/png/extract_chunks.py
+++ b/image/png/extract_chunks.py
@@ -76,6 +76,23 @@ def copyfileobj_with_limit(
     return remaining
 
 
+def open_no_clobber(path: Path) -> typing.BinaryIO:
+    """Open `path` for exclusive binary writing, refusing to overwrite.
+
+    Output names in `-d` mode are derived from the input's base name, so inputs
+    that share a base name would otherwise clobber each other. The collision can
+    even span separate invocations (e.g. when `xargs` splits the file list into
+    batches), so we detect it at the actual write rather than up front.
+    """
+    try:
+        return path.open("xb")
+    except FileExistsError as e:
+        raise ValueError(
+            f"refusing to overwrite existing output file {path};"
+            f" clean the output directory and re-run"
+        ) from e
+
+
 def run_single(file_path: Path, chunk_type: str, outfile: Path) -> None:
     validate_chunk_type(chunk_type)
 
@@ -128,7 +145,7 @@ def run(files: list[Path], chunk_types: set[str], outdir: Path) -> None:
                     continue
                 name = f"{file_path.name}-{i:0{index_width}d}.bin"
                 out_path = outdir / chunk_type / name
-                with out_path.open("wb") as out_f:
+                with open_no_clobber(out_path) as out_f:
                     f.seek(span.offset)
                     remaining = copyfileobj_with_limit(f, out_f, span.length)
                 if remaining > 0:
@@ -136,7 +153,13 @@ def run(files: list[Path], chunk_types: set[str], outdir: Path) -> None:
                         f"{file_path}: chunk {i} of type {chunk_type!r} is truncated"
                         f" (wanted {span.length} bytes, but only {span.length - remaining} bytes written)"
                     )
-                    out_path.replace(out_path.with_name(name + ".trunc"))
+                    trunc_path = out_path.with_name(name + ".trunc")
+                    if trunc_path.exists():
+                        raise ValueError(
+                            f"refusing to overwrite existing output file {trunc_path};"
+                            f" clean the output directory and re-run"
+                        )
+                    out_path.rename(trunc_path)
 
 
 def main() -> None:

--- a/image/png/extract_chunks.py
+++ b/image/png/extract_chunks.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env -S uv run --script
+
+# SPDX-FileCopyrightText: 2026 Petr Pucil <petr.pucil@seznam.cz>
+#
+# SPDX-License-Identifier: MIT
+
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+
+import argparse
+import os
+import re
+import struct
+import typing
+from dataclasses import dataclass
+from pathlib import Path
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+PNG_CHUNK_TYPE_RE = re.compile(r"[A-Za-z]{4}")
+
+PACKER_U4BE = struct.Struct(">I")
+
+
+@dataclass
+class ChunkBodySpan:
+    type: str
+    offset: int
+    length: int
+
+
+def get_chunk_body_spans(f: typing.BinaryIO) -> list[ChunkBodySpan]:
+    chunk_spans = []
+
+    if f.read(8) != PNG_SIGNATURE:
+        raise ValueError("not a PNG image")
+
+    while True:
+        chunk_len_raw = f.read(4)
+        if not chunk_len_raw:
+            break
+        len_body = PACKER_U4BE.unpack(chunk_len_raw)[0]
+        chunk_type = f.read(4).decode("ascii")
+        if len(chunk_type) != 4:
+            raise ValueError("unexpected EOF in the middle of 4-byte chunk type")
+        ofs_body = f.tell()
+        f.seek(len_body + 4, os.SEEK_CUR)
+        chunk_spans.append(ChunkBodySpan(chunk_type, ofs_body, len_body))
+        if chunk_type == "IEND":
+            break
+
+    return chunk_spans
+
+
+def copyfileobj_with_limit(
+    src: typing.BinaryIO, dst: typing.BinaryIO, limit: int, *, buffer_size=256 * 1024
+) -> int:
+    """Like shutil.copyfileobj(), but with a limit on the number of bytes to copy."""
+
+    remaining = limit
+    while remaining > 0:
+        buf = src.read(min(buffer_size, remaining))
+        if not buf:
+            break
+        dst.write(buf)
+        remaining -= len(buf)
+
+    return remaining
+
+
+def run_single(file_path: Path, chunk_type: str, outfile: Path) -> None:
+    if PNG_CHUNK_TYPE_RE.fullmatch(chunk_type) is None:
+        raise ValueError(
+            f"expected an ASCII 4-letter chunk type, but got {chunk_type!r}"
+        )
+
+    with file_path.open("rb") as f:
+        chunk_body_spans = get_chunk_body_spans(f)
+
+        matching = [span for span in chunk_body_spans if span.type == chunk_type]
+
+        if len(matching) == 0:
+            raise ValueError(f"{file_path}: no chunk of type {chunk_type!r} found")
+        if len(matching) > 1:
+            raise ValueError(
+                f"{file_path}: expected exactly one chunk of type {chunk_type!r},"
+                f" but found {len(matching)}"
+            )
+
+        span = matching[0]
+        f.seek(span.offset)
+        with outfile.open("wb") as out_f:
+            remaining = copyfileobj_with_limit(f, out_f, span.length)
+
+    if remaining > 0:
+        raise ValueError(
+            f"{file_path}: chunk of type {chunk_type!r} is truncated"
+            f" (wanted {span.length} bytes, but only {span.length - remaining} bytes written)"
+        )
+
+
+def run(files: list[Path], chunk_types: set[str], outdir: Path) -> None:
+    outdir.mkdir(exist_ok=True)
+    for chunk_type in chunk_types:
+        if PNG_CHUNK_TYPE_RE.fullmatch(chunk_type) is None:
+            raise ValueError(
+                f"expected an ASCII 4-letter chunk type, but got {chunk_type!r}"
+            )
+
+        (outdir / chunk_type).mkdir(exist_ok=True)
+
+    for file_path in files:
+        with file_path.open("rb") as f:
+            chunk_body_spans = get_chunk_body_spans(f)
+            for i, span in enumerate(chunk_body_spans):
+                chunk_type = span.type
+                if chunk_type not in chunk_types:
+                    continue
+                out_path = outdir / chunk_type / f"{file_path.name}-{i}.bin"
+                with out_path.open("wb") as out_f:
+                    f.seek(span.offset)
+                    remaining = copyfileobj_with_limit(f, out_f, span.length)
+                if remaining > 0:
+                    print(
+                        f"{file_path}: chunk {i} of type {chunk_type!r} is truncated"
+                        f" (wanted {span.length} bytes, but only {span.length - remaining} bytes written)"
+                    )
+                    out_path.replace(
+                        outdir / chunk_type / f"{file_path.name}-{i}.bin.trunc"
+                    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract specific chunks from PNG files"
+    )
+    parser.add_argument(
+        "files",
+        nargs="+",
+        type=Path,
+        help="input PNG (.png) files to process",
+        metavar="FILE",
+    )
+    parser.add_argument(
+        "-t",
+        "--chunk-type",
+        required=True,
+        dest="chunk_types",
+        action="append",
+        help="chunk type(s) to extract",
+        metavar="TYPE",
+    )
+    output_group = parser.add_mutually_exclusive_group(required=True)
+    output_group.add_argument(
+        "-d",
+        "--outdir",
+        dest="outdir",
+        type=Path,
+        help="output directory",
+        metavar="DIR",
+    )
+    output_group.add_argument(
+        "-o",
+        "--outfile",
+        dest="outfile",
+        type=Path,
+        help="output file; requires exactly one input FILE and one -t TYPE,"
+        " and the input must contain exactly one chunk of that type",
+        metavar="FILE",
+    )
+    args = parser.parse_args()
+
+    if args.outfile is not None:
+        if len(args.files) != 1:
+            parser.error("-o/--outfile requires exactly one input file")
+        if len(args.chunk_types) != 1:
+            parser.error("-o/--outfile requires exactly one -t/--chunk-type")
+        run_single(args.files[0], args.chunk_types[0], args.outfile)
+    else:
+        run(args.files, set(args.chunk_types), args.outdir)
+
+
+if __name__ == "__main__":
+    main()

--- a/image/png/extract_chunks.py
+++ b/image/png/extract_chunks.py
@@ -12,15 +12,12 @@
 import argparse
 import os
 import re
-import struct
 import typing
 from dataclasses import dataclass
 from pathlib import Path
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 PNG_CHUNK_TYPE_RE = re.compile(r"[A-Za-z]{4}")
-
-PACKER_U4BE = struct.Struct(">I")
 
 
 def validate_chunk_type(chunk_type: str) -> None:
@@ -47,10 +44,16 @@ def get_chunk_body_spans(f: typing.BinaryIO) -> list[ChunkBodySpan]:
         chunk_len_raw = f.read(4)
         if not chunk_len_raw:
             break
-        len_body = PACKER_U4BE.unpack(chunk_len_raw)[0]
-        chunk_type = f.read(4).decode("ascii")
-        if len(chunk_type) != 4:
-            raise ValueError("unexpected EOF in the middle of 4-byte chunk type")
+        if len(chunk_len_raw) != 4:
+            raise ValueError("unexpected EOF while reading the chunk length")
+        len_body = int.from_bytes(chunk_len_raw, "big")
+        chunk_type_raw = f.read(4)
+        if len(chunk_type_raw) != 4:
+            raise ValueError("unexpected EOF while reading the chunk type")
+        try:
+            chunk_type = chunk_type_raw.decode("ascii")
+        except UnicodeDecodeError as e:
+            raise ValueError(f"invalid non-ASCII chunk type {chunk_type_raw!r}") from e
         ofs_body = f.tell()
         f.seek(len_body + 4, os.SEEK_CUR)
         chunk_spans.append(ChunkBodySpan(chunk_type, ofs_body, len_body))


### PR DESCRIPTION
The approach using the `grep`, `xxd` and `dd` commands, which has been demonstrated several times in the `image/png/README.md` file, is largely manual and not scalable for more than a few samples. I'm not aware of any existing tool that can easily extract PNG chunks by type, which is why I wrote this script.

Cc @armijnhemel